### PR TITLE
Update FineUploaderWidget.php

### DIFF
--- a/widgets/FineUploaderWidget.php
+++ b/widgets/FineUploaderWidget.php
@@ -401,7 +401,10 @@ class FineUploaderWidget extends \Widget
 
 			foreach ($this->varValue as $varFile)
 			{
-				if (\Validator::isUuid($varFile) && !is_file(TL_ROOT . '/' . $varFile))
+				$file = \FilesModel::findByUuid($varFile);
+                            	$filePath = $file->path;
+                            
+				if (\Validator::isUuid($varFile) && !is_file($filePath))
 				{
 					$arrUuids[] = $varFile;
 				}


### PR DESCRIPTION
fixed "Warning: is_file() expects parameter 1 to be a valid path, string given in"
See https://github.com/terminal42/contao-fineuploader/issues/2
