### PR TITLE
Include class in system log entry

### DIFF
--- a/src/RequestHandler/FrontendHandler.php
+++ b/src/RequestHandler/FrontendHandler.php
@@ -65,10 +65,13 @@ class FrontendHandler
         try {
             $response = $this->dispatchRequest($request, $widget);
         } catch (\Exception $e) {
+            $caller = $e->getTrace()[1];
+            $func = $caller['class'].'::'.$caller['function'];
+
             $this->logger->log(
                 LogLevel::ERROR,
                 $e->getMessage(),
-                ['contao' => new ContaoContext(($e->getTrace())[1]['function'], TL_ERROR)]
+                ['contao' => new ContaoContext($func, TL_ERROR)]
             );
 
             $response = new Response('Bad Request', 400);


### PR DESCRIPTION
Currently a system log entry caused by an exception during the upload will look like this for example:

![Screenshot_2020-07-22 System-Log kastner-website-v2 local](https://user-images.githubusercontent.com/4970961/88181365-a3f83e00-cc26-11ea-8a13-729e417925ca.png)

It only tells you the function name, but not the class - which would be standard behaviour for other system log entries.

With the change in this PR, the log entry will look like this:

![Screenshot_2020-07-22 System-Log kastner-website-v2 local(1)](https://user-images.githubusercontent.com/4970961/88181433-be321c00-cc26-11ea-8c40-ac2f4c9d2775.png)

Just like other system log entries.