### PR TITLE
Transform uuid to path

### DIFF
--- a/src/EventListener/FileUploadListener.php
+++ b/src/EventListener/FileUploadListener.php
@@ -14,6 +14,8 @@ namespace Terminal42\FineUploaderBundle\EventListener;
 
 use Contao\Config;
 use Contao\File;
+use Contao\FilesModel;
+use Contao\Validator;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Terminal42\FineUploaderBundle\Event\FileUploadEvent;
 use Terminal42\FineUploaderBundle\Uploader;
@@ -50,6 +52,10 @@ class FileUploadListener
             ]));
 
             return;
+        }
+
+        if (Validator::isUuid($filePath)) {
+            $filePath = FilesModel::findByUuid($filePath)->path;
         }
 
         // Validate the image dimensions for the frontend widget

--- a/src/EventListener/FileUploadListener.php
+++ b/src/EventListener/FileUploadListener.php
@@ -55,7 +55,19 @@ class FileUploadListener
         }
 
         if (Validator::isUuid($filePath)) {
-            $filePath = FilesModel::findByUuid($filePath)->path;
+            $fileModel = FilesModel::findByUuid($filePath);
+
+            if (null === $fileModel) {
+                $event->setResponse(new JsonResponse([
+                    'success' => false,
+                    'error' => $GLOBALS['TL_LANG']['ERR']['general'],
+                    'preventRetry' => true,
+                ]));
+    
+                return;
+            }
+
+            $filePath = $fileModel->path;
         }
 
         // Validate the image dimensions for the frontend widget


### PR DESCRIPTION
If you have `addToDbafs` enabled, then `Uploader::upload` will return a binary UUID, not a path (see `Uploader::storeFile`). This in turn will cause the following error:

```
Malformed UTF-8 characters, possibly incorrectly encoded
```
because the `FileUploadListener` then tries to `json_encode` this binary UUID.

This PR simply fetches the `FilesModel` instance of the file from the model registry and uses the file path again.