### PR TITLE
Fix max dimensions check

### DIFF
--- a/src/EventListener/FileUploadListener.php
+++ b/src/EventListener/FileUploadListener.php
@@ -87,12 +87,12 @@ class FileUploadListener
 
             // Image exceeds maximum image width
             if ($maxWidth > 0 && $file->width > $maxWidth) {
-                $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['filewidth'], '', $maxWidth));
+                $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['filewidth'], basename($filePath), $maxWidth));
             }
 
             // Image exceeds maximum image height
             if ($maxHeight > 0 && $file->height > $maxHeight) {
-                $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['fileheight'], '', $maxHeight));
+                $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['fileheight'], basename($filePath), $maxHeight));
             }
         }
     }

--- a/src/EventListener/FileUploadListener.php
+++ b/src/EventListener/FileUploadListener.php
@@ -80,16 +80,18 @@ class FileUploadListener
         $file = new File($filePath);
 
         if ($file->isImage) {
-            $maxWidth = Config::get('imageWidth');
-            $maxHeight = Config::get('imageHeight');
+            $config = $widget->getUploaderConfig();
+
+            $maxWidth = $config->getMaxImageWidth() ?: Config::get('imageWidth');
+            $maxHeight = $config->getMaxImageHeight() ?: Config::get('imageHeight');
 
             // Image exceeds maximum image width
-            if ($file->width > $maxWidth) {
+            if ($maxWidth > 0 && $file->width > $maxWidth) {
                 $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['filewidth'], '', $maxWidth));
             }
 
             // Image exceeds maximum image height
-            if ($file->height > $maxHeight) {
+            if ($maxHeight > 0 && $file->height > $maxHeight) {
                 $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['fileheight'], '', $maxHeight));
             }
         }

--- a/src/EventListener/FileUploadListener.php
+++ b/src/EventListener/FileUploadListener.php
@@ -87,12 +87,12 @@ class FileUploadListener
 
             // Image exceeds maximum image width
             if ($maxWidth > 0 && $file->width > $maxWidth) {
-                $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['filewidth'], basename($filePath), $maxWidth));
+                $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['filewidth'], '', $maxWidth));
             }
 
             // Image exceeds maximum image height
             if ($maxHeight > 0 && $file->height > $maxHeight) {
-                $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['fileheight'], basename($filePath), $maxHeight));
+                $widget->addError(sprintf($GLOBALS['TL_LANG']['ERR']['fileheight'], '', $maxHeight));
             }
         }
     }


### PR DESCRIPTION
There two problems with the current `validateImageDimensions` check.

1. It ignores the `maxWidth`/`maxHeight` variables set in the configuration of the widget.
2. It does not check whether an `imageWidth`/`imageHeight` is actually set.

ad 2) so if you haven't set `imageWidth` or `imageHeight` in your config, then the following error in the front end will occur:

```
File  exceeds the maximum image width of 0 pixels!
```