### PR TITLE
Pass file path to storeFile instead of array

### DIFF
--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -78,7 +78,7 @@ class Uploader
 
         // Validate and move the file immediately
         if ($config->isDirectUploadEnabled() && !$isChunk) {
-            $filePath = $this->storeFile($config, $result);
+            $filePath = $this->storeFile($config, $filePath);
         }
 
         return $filePath;


### PR DESCRIPTION
When using `storeFile => true`, the upload won't work and the following message will appear in the system log:

```
Warning: strlen() expects parameter 1 to be string, array given
```

This is because `$result` is the resulting array (containing one element with the file's path) from the `\Contao\FileUpload::uploadTo` function - but `Uploader::storeFile` expects the file path as a string.