### PR TITLE
Fix session usage

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -40,7 +40,6 @@ services:
         class: Terminal42\FineUploaderBundle\WidgetHelper
         arguments:
             - "@terminal42_fineuploader.filesystem"
-            - "@session"
 
     # Request handlers
     terminal42_fineuploader.request.backend_handler:

--- a/src/WidgetHelper.php
+++ b/src/WidgetHelper.php
@@ -20,7 +20,6 @@ use Contao\Model\Collection;
 use Contao\StringUtil;
 use Contao\System;
 use Contao\Template;
-use Symfony\Component\HttpFoundation\Session\Session;
 use Terminal42\FineUploaderBundle\Widget\BaseWidget;
 
 class WidgetHelper
@@ -31,17 +30,11 @@ class WidgetHelper
     private $fs;
 
     /**
-     * @var Session
-     */
-    private $session;
-
-    /**
      * WidgetHelper constructor.
      */
-    public function __construct(Filesystem $fs, Session $session)
+    public function __construct(Filesystem $fs)
     {
         $this->fs = $fs;
-        $this->session = $session;
     }
 
     /**

--- a/src/WidgetHelper.php
+++ b/src/WidgetHelper.php
@@ -119,8 +119,6 @@ class WidgetHelper
     public function addFilesToSession($name, array $files): void
     {
         $count = 0;
-        $sessionKey = 'FILES';
-        $sessionFiles = $this->session->get($sessionKey);
 
         foreach ($files as $filePath) {
             $model = null;
@@ -136,7 +134,7 @@ class WidgetHelper
 
             $file = new File($filePath);
 
-            $sessionFiles[$name.'_'.$count++] = [
+            $_SESSION['FILES'][$name.'_'.$count++] = [
                 'name' => $file->name,
                 'type' => $file->mime,
                 'tmp_name' => TL_ROOT.'/'.$file->path,
@@ -146,8 +144,6 @@ class WidgetHelper
                 'uuid' => (null !== $model) ? StringUtil::binToUuid($model->uuid) : '',
             ];
         }
-
-        $this->session->set($sessionKey, $sessionFiles);
     }
 
     /**


### PR DESCRIPTION
Fixes #63

The point of `WidgetHelper::addFilesToSession` was (presumably) to make `Contao\Form::processFormData` behave in the same way as with the regular file upload. i.e. if email sending is enabled, Contao will either attach the uploaded file to the email or append the absolute path to the image for easy access/download (when file storing is enabled).

However, this is currently not the case with the FineUploader. Any uploaded files only show up in the regular email content, with `field name: relative/file/path`. Uploaded files are not attached, nor is a direct link appended to the email by Contao.

This is because `WidgetHelper::addFilesToSession` uses Symfony's Session service to write the information to the session. However, Symfony's Session stores all session data always in "session bags" with unique namespaces (see [Session Data Management](https://symfony.com/doc/current/components/http_foundation/sessions.html#session-data-management)), not directly to `$_SESSION`, in order to not interfere with other session data. `Contao\Form::processFormData` however uses `$_SESSION['FILES']` directly, without Symfony's Session service - thus this never worked.

This PR fixes that by instead writing the session data directly to `$_SESSION['FILES']` as expected from `Contao\Form::processFormData`.

_Note:_ the Symfony Session is still added via Dependency Injection to the `WidgetHelper`, even though nothing in it uses it any more. Should I remove it?