### PR TITLE
Do not throw exception on invalid config

### DIFF
--- a/src/Widget/BaseWidget.php
+++ b/src/Widget/BaseWidget.php
@@ -66,7 +66,7 @@ abstract class BaseWidget extends Widget
             case 'imageSize':
             case 'uploaderConfig':
                 if (!\is_array($value)) {
-                    throw new \InvalidArgumentException(sprintf('The "%s" must be an array', $key));
+                    return;
                 }
 
                 $this->arrConfiguration[$key] = $value;


### PR DESCRIPTION
In my system, I have a custom `imageSize` field added to `tl_form_field`. The database value is empty by default. This results in the back end form generator not being accessible anymore because it always throws an exception.

The default form field does not have an `imageSize` configuration at all, I assume this is meant to be used by devs only. I think ignoring invalid values here would be sufficient wdyt?