### PR TITLE
Update FileUpload.php

### DIFF
--- a/src/FileUpload.php
+++ b/src/FileUpload.php
@@ -30,6 +30,8 @@ class FileUpload extends \Contao\FileUpload
     public function __construct(string $name)
     {
         parent::__construct();
+        
+        System::loadLanguageFile('tl_settings');
 
         $this->setName($name);
 
@@ -161,7 +163,7 @@ class FileUpload extends \Contao\FileUpload
         Config::set('uploadTypes', implode(',', $this->extensions));
 
         $filesizeLabel = $GLOBALS['TL_LANG']['ERR']['filesize'];
-        $GLOBALS['TL_LANG']['ERR']['filesize'] = $GLOBALS['TL_LANG']['ERR']['maxFileSize'];
+        $GLOBALS['TL_LANG']['ERR']['filesize'] = $GLOBALS['TL_LANG']['tl_settings']['maxFileSize'];
 
         // Perform upload
         $result = parent::uploadTo($target);


### PR DESCRIPTION
In Debug mode (APP_ENV=dev, PHP 8.1, Contao 4.13) i get an error on uploading a file in the backend. This is because the maxFileSize isn't set in $GLOBALS['TL_LANG']['ERR'].