### PR TITLE
fixed wrong set session

### DIFF
--- a/src/ChunkUploader.php
+++ b/src/ChunkUploader.php
@@ -54,7 +54,7 @@ class ChunkUploader
         }
 
         // Update the session
-        $this->requestStack->getSession()->get($sessionKey, $chunks);
+        $this->requestStack->getSession()->set($sessionKey, $chunks);
 
         return $filePath;
     }


### PR DESCRIPTION
fixed wrong set session - This prevents the issue that a file could not moved to the target folder, when chunking is enabled.