### PR TITLE
Restore session usage for Contao 4.13

### DIFF
--- a/src/Widget/FrontendWidget.php
+++ b/src/Widget/FrontendWidget.php
@@ -67,6 +67,14 @@ class FrontendWidget extends BaseWidget
     }
 
     /**
+     * Do not submit input if file will not be stored.
+     */
+    public function submitInput()
+	{
+		return $this->storeFile;
+	}
+
+    /**
      * Store the file information in the session to reproduce Contao 4.13 uploader behavior.
      */
     protected function validator($input)

--- a/src/Widget/FrontendWidget.php
+++ b/src/Widget/FrontendWidget.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Terminal42\FineUploaderBundle\Widget;
 
+use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\CoreBundle\Exception\ResponseException;
 use Contao\FrontendTemplate;
+use Contao\System;
 
 class FrontendWidget extends BaseWidget
 {
@@ -62,6 +64,20 @@ class FrontendWidget extends BaseWidget
     public function getValuesTemplate()
     {
         return new FrontendTemplate($this->valuesTemplate ?: 'fineuploader_values_frontend');
+    }
+
+    /**
+     * Store the file information in the session to reproduce Contao 4.13 uploader behavior.
+     */
+    protected function validator($input)
+    {
+        $return = parent::validator($input);
+
+        if (version_compare(ContaoCoreBundle::getVersion(), '5@dev', '<')) {
+            $this->getWidgetHelper()->addFilesToSession($this->strName, array_filter((array) $return), $this->storeFile);
+        }
+
+        return $return;
     }
 
     /**

--- a/src/WidgetHelper.php
+++ b/src/WidgetHelper.php
@@ -99,6 +99,45 @@ class WidgetHelper
     }
 
     /**
+     * Add the files to the session in order to reproduce Contao 4.13 uploader behavior.
+     *
+     * @param string $name
+     */
+    public function addFilesToSession($name, array $files, bool $storeFile = true): void
+    {
+        $count = 0;
+
+        foreach ($files as $filePath) {
+            $model = null;
+
+            // Get the file model
+            if (Validator::isUuid($filePath)) {
+                if (null === ($model = FilesModel::findByUuid($filePath))) {
+                    continue;
+                }
+
+                $filePath = $model->path;
+            }
+
+            $file = new File($filePath);
+
+            if (!$file->exists()) {
+                continue;
+            }
+
+            $_SESSION['FILES'][$name.'_'.$count++] = [
+                'name' => $file->name,
+                'type' => $file->mime,
+                'tmp_name' => TL_ROOT.'/'.$file->path,
+                'error' => 0,
+                'size' => $file->size,
+                'uploaded' => $storeFile,
+                'uuid' => null !== $model ? StringUtil::binToUuid($model->uuid) : '',
+            ];
+        }
+    }
+
+    /**
      * Generate the item template.
      *
      * @param string $id


### PR DESCRIPTION
Fixes #93 (see https://github.com/terminal42/contao-fineuploader/issues/93#issuecomment-1910187313).

This restores the parts that got removed in #92. In addition it also fixes that files were not attached by Contao previously (because `'uploaded'` was always set to `true`. It needs to be `false` for `\Contao\Form` to attach the file for the cases where the file is not stored).